### PR TITLE
Properly restore BSON::ObjectId from ES document using :model wrapper.

### DIFF
--- a/lib/mongoid/elasticsearch/response.rb
+++ b/lib/mongoid/elasticsearch/response.rb
@@ -148,6 +148,11 @@ module Mongoid
         hits.map do |h|
           klass = find_klass(h['_type'])
           source = h.delete('_source')
+          source.each do |k,v|
+            if v.is_a?(Hash) && v.has_key?("$oid")
+              source[k] = BSON::ObjectId.from_string(v["$oid"])
+            end
+          end
           begin
             m = klass.new(h.merge(source))
           rescue Mongoid::Errors::UnknownAttribute

--- a/spec/models/post.rb
+++ b/spec/models/post.rb
@@ -4,10 +4,12 @@ class Post
   field :name, type: String
   field :content, type: String
 
+  field :my_object_id, type: BSON::ObjectId
+
   include Mongoid::Elasticsearch
   elasticsearch!
   def as_indexed_json
-    {name: name, content: content}
+    {name: name, content: content, my_object_id: my_object_id}
   end
 end
 

--- a/spec/mongoid_elasticsearch_spec.rb
+++ b/spec/mongoid_elasticsearch_spec.rb
@@ -44,7 +44,9 @@ describe Article do
       @article_1 = Article.create!(name: 'test article name likes', tags: 'likely')
       @article_2 = Article.create!(name: 'tests likely an another article title')
       @article_3 = Article.create!(name: 'a strange name for this stuff')
+      @post_1 = Post.create!(name: 'object_id', my_object_id: BSON::ObjectId.new)
       Article.es.index.refresh
+      Post.es.index.refresh
     end
 
     it 'searches and returns models' do
@@ -70,6 +72,12 @@ describe Article do
       results.first.slug.should eq @article_2.name.to_url
       results.first.to_param.should eq @article_2.name.to_url
       expect(Article).to_not have_received(:find)
+    end
+
+    it 'restores BSON::ObjectId with wrapper :model' do
+      results = Post.es.search 'object_id'
+      results.first.my_object_id.should be_kind_of(BSON::ObjectId)
+      results.first.my_object_id.should eq(@post_1.my_object_id)
     end
 
 


### PR DESCRIPTION
When you use :model wrapper, and it loads object attributes from ES to Mongoid model, it sets your association's id as {"$oid" => BSON::ObjectId()}, where it should just be BSON::ObjectId().

Some related info
https://github.com/mongoid/mongoid/pull/2947

https://github.com/rs-pro/mongoid-elasticsearch/issues/1
