### PR TITLE
Added skip_create option to prevent automatic creating of index

### DIFF
--- a/lib/mongoid/elasticsearch.rb
+++ b/lib/mongoid/elasticsearch.rb
@@ -77,7 +77,7 @@ module Mongoid
         include Indexing
         include Callbacks if options[:callbacks]
 
-        es.index.create
+        es.index.create unless options[:skip_create]
       end
     end
 


### PR DESCRIPTION
We create aliases to indexes and already have a module that handles this for us. We've added a simple option to skip the automatic creation of the index.
